### PR TITLE
added preprocessor switch for domoticz not in use

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -541,7 +541,9 @@ void mqtt_connected()
       mqtt_publish(stopic, svalue);
     }
     status_update_timer = 2;
+#ifdef USE_DOMOTICZ
     domoticz_update_timer = 2;
+#endif  // USE_DOMOTICZ
   }
   mqttflag = 0;
 }


### PR DESCRIPTION
Preprocessor switch is missing and leads to compile error if USE_DOMOTICZ is not defined.