### PR TITLE
minor syntax fix

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1432,7 +1432,7 @@ void every_second()
       }
     }
   }
-#endif  \\ USE_DOMOTICZ
+#endif  // USE_DOMOTICZ
 
   if (sysCfg.tele_period) {
     tele_period++;


### PR DESCRIPTION
Fixes:
```
sonoff/sonoff.ino:1435:8: warning: extra tokens at end of #endif directive [enabled by default]
#endif  \\ USE_DOMOTICZ
```