### PR TITLE
fix compiler warning

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -580,7 +580,7 @@ void CFG_Delta()
 
 /********************************************************************************************/
 
-void getClient(char* output, char* input, byte size)
+void getClient(char* output, const char* input, byte size)
 {
   char *token;
   uint8_t digits = 0;


### PR DESCRIPTION
Fixing a minor warning:

```
sonoff/webserver.ino: In function 'void handleMqtt()':
sonoff/webserver.ino:654:60: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
getClient(str, MQTT_CLIENT_ID, sizeof(sysCfg.mqtt_client));
```


PS: @arendst did you know you can use https://github.com/arendst/Sonoff-MQTT-OTA-Arduino/releases instead of copying releases to separate directories? It can improve the readability of the commits greatly. Just a thought