### PR TITLE
Add options to POWERONSTATE for only when device is actually powered on.

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1129,7 +1129,7 @@ void mqttDataCb(char* topic, byte* data, unsigned int data_len)
     }
 #if (MODULE != MOTOR_CAC)
     else if (!strcmp(type,"POWERONSTATE")) {
-      if ((data_len > 0) && (payload >= 0) && (payload <= 3)) {
+      if ((data_len > 0) && (payload >= 0) && (payload <= 5)) {
         sysCfg.poweronstate = payload;
       }
       snprintf_P(svalue, sizeof(svalue), PSTR("{\"PowerOnState\":%d}"), sysCfg.poweronstate);
@@ -1686,7 +1686,7 @@ void send_button_power(byte device, byte state)
   snprintf_P(stemp1, sizeof(stemp1), PSTR("%d"), device);
   snprintf_P(stopic, sizeof(stopic), PSTR("%s/%s/%s%s"),
     SUB_PREFIX, sysCfg.mqtt_topic2, sysCfg.mqtt_subtopic, (Maxdevice > 1) ? stemp1 : "");
-  
+
   if (state == 3) {
     svalue[0] = '\0';
   } else {
@@ -2549,11 +2549,11 @@ void setup()
     power = 0;
     setRelay(power);
   }
-  else if (sysCfg.poweronstate == 1) {  // All on
+  else if (sysCfg.poweronstate == 1 || (sysCfg.poweronstate == 4 && ESP.getResetReason() == "Power on")) {  // All on
     power = ((0x00FF << Maxdevice) >> 8);
     setRelay(power);
   }
-  else if (sysCfg.poweronstate == 2) {  // All saved state toggle
+  else if (sysCfg.poweronstate == 2 || (sysCfg.poweronstate == 5 && ESP.getResetReason() == "Power on")) {  // All saved state toggle
     power = (sysCfg.power & ((0x00FF << Maxdevice) >> 8)) ^ 0xFF;
     if (sysCfg.savestate) setRelay(power);
   }

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -125,7 +125,7 @@
 #define APP_TIMEZONE           1            // [Timezone] +1 hour (Amsterdam) (-12 .. 12 = hours from UTC, 99 = use TIME_DST/TIME_STD)
 #define APP_LEDSTATE           LED_POWER    // [LedState] Function of led (LED_OFF, LED_POWER, LED_MQTTSUB, LED_POWER_MQTTSUB, LED_MQTTPUB, LED_POWER_MQTTPUB, LED_MQTT, LED_POWER_MQTT)
 #define APP_PULSETIME          0            // [PulseTime] Time in 0.1 Sec to turn off power for relay 1 (0 = disabled)
-#define APP_POWERON_STATE      3            // [PowerOnState] Power On Relay state (0 = Off, 1 = On, 2 = Toggle Saved state, 3 = Saved state)
+#define APP_POWERON_STATE      3            // [PowerOnState] Power On Relay state (0 = Off, 1 = On, 2 = Toggle Saved state, 3 = Saved state, 4 = On after power up, else use saved state after a reset etc., 5 = Only toggle saved state after a power on, not a restart)
 #define APP_BLINKTIME          10           // [BlinkTime] Time in 0.1 Sec to blink/toggle power for relay 1
 #define APP_BLINKCOUNT         10           // [BlinkCount] Number of blinks (0 = 32000)
 


### PR DESCRIPTION
TL;DR: All my lights etc. shouldn't turn on just because the WiFi router
reboots or I upload a new version of this software.

ESP8266s can tell if they were powered on or are restarted for numerous reasons.
Add POWERONSTATEs which are only acted upon if we detect the ESP8266 was
powered on, not just reset. Only makes sense if SAVESTATE is on.
e.g. '4' to turn on the relay only at power up, not just every restart.
     '5' to toggle the relay only at power up, not just every restart.

This solves an issue where the relay state is being changed if network
connection is lost.

Scenario:
Sonoff is in series between a device and a wall switch.
Desired action is to emulate traditional device behaviour when wall switch is
turned on. i.e. Physically present human can always turn on device.
If the switch is kept in on state, the device is left to be controlled by the
sonoff. When the sonoff loses network connection, or is updated etc. the
default action of 'POWERONSTATE 1' would be triggered, turning on the relay.
If the relay was previously off, the desired state would change.
'POWERONSTATE 4' preserves that state, but allows a human change the state
via the physical switch.

Note: MQTT Retain doesn't fit this scenario if POWER state was retained.
If the POWERONSTATE was 1, and the previous retained relay state was POWER OFF,
at device reset/restart (not just power on) a new 'POWER ON' state would be
transmitted and retained. Not the desired result.