### PR TITLE
Update platformio.ini to include missing lib & migrate to next gen release

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; http://docs.platformio.org/en/stable/projectconf.html
 
 [platformio]
-src_dir = sonoff
+src_dir = next_gen/sonoff
 
 [env:sonoff]
 platform = espressif8266
@@ -19,4 +19,4 @@ board = esp01_1m
 ; board = esp8285
 build_flags = -Wl,-Tesp8266.flash.1m64.ld -DMQTT_MAX_PACKET_SIZE=400
 
-lib_deps = PubSubClient
+lib_deps = PubSubClient, NeoPixelBus


### PR DESCRIPTION
Small update to include NeoPixelBus library and change the main folder to "next gen"