### PR TITLE
Adding Travis CI [token needs to be changed]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - '2.7'
+sudo: false
+cache:
+  directories:
+    - "~/.platformio"
+install:
+    - pip install -U platformio
+
+script:
+    - platformio run
+deploy:
+  provider: releases
+  api_key:
+    secure: trZaUjfjitidddXN5FmeTLQPw9Dr+f9nEEb/T/YTZNRVYce1VgHL3QOKQIBUzgvobsdYdCP3DSO0H0XdiFe5uuTUPkmeYGl/GIM5PdfGRcVrMiw0f+WmzKjS8reP4qXUnDaPd6HDxcWzz6B5Y9r7ILbezELRhUAYpRQzaNzVIObZwgYIXtaH5xt/xyrQhHu4rHErk9ihVjrVRE06hOco7/smo4qPR+Ve98yg0/wwGfW3uBseSFVG6nN3jg00RtIZFdOL7qCwfn0WyuC2ec8OfZzfl0UmArSmycnQvpwRW/T4mnS6gOqyz16kahK7q6wR9/R3jiCBRQlzhl9S7WTok8G6i3+uF6/Wd1h56VDr+ESuig8DClV0XivPdWq0spMEQ0bNJZfcJeQYJDvcFk8vlULDhA5WUF44t9+oS2d1dPwjwPFhu7ne3hDG8F+z3F1yMDvwXqyuFWbwbj5Yq9lE/iVYfj4skHNwHbUry4QbJHMns+DTdXAjnaiaOH9lxlh0kphlLlLPD7qPvNscHpe0liQsld9s36noF3W7MC+4YaCEfC11ltltrIQayey/RaXAzUreZdKWlU9pZKFYF1KKwyvMj9WfK/vILZweLApXVPs1Pxz3A8+gJhaGO8tB8ytRKddgvSMlkmh5cG7jd3zcEsnKGvkauofhWzZRodBDk8U=
+  file: ".pioenvs/sonoff/firmware.bin"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Hi Theo,

Here is a small update that is a part of a larger concept.

I'm following up to my previous concepts: #80 & #83.

With the "next gen" version it becomes possible to release a common binary that could be automagically downloaded by all the Sonoffs worldwide on demand OTA.

Here are the steps to make it happen:

1. Including TravisCI into the workflow by creating an account here: https://travis-ci.org/ (free)
2. Pulling the changes from this PR
3. Updating the api_key (securely: https://docs.travis-ci.com/user/deployment/releases/#Authenticating-with-an-Oauth-token)
4. Moving to github releases workflow (https://github.com/arendst/Sonoff-MQTT-OTA-Arduino/releases) so that TravisCI can build and upload the firmware.bin file after each release.

With this in place people can potentially head to https://github.com/arendst/Sonoff-MQTT-OTA-Arduino/releases/latest, figure out a correct url to download the firmware (example on my fork: https://github.com/wiktorschmidt/Sonoff-MQTT-OTA-Arduino/releases/latest) put it into OTAURL and send tell Sonoff to update. Unfortunately, as you know, the firmware can't handle HTTPS and github is only exposing HTTPS endpoint. This means we have a few additional steps on the user side. I'm assuming people are using Node-Red:

5. Pull a flow https://flows.nodered.org/flow/59f91e93ef1c5ce73a294e6c4e883b26 (this creates a simple proxy and automates pulling the latest release)
6. point OTAURL to http://node-red-ip:port/sonoff
7. initiate Upgrade

Why I think it's an interesting approach:
1. Allows one-click upgrade to people who trust you to release stable updates.
2. Uses "proper CI" and helps prevent possible compile errors.
3. Helps track new releases (via RSS, Slack notifications, etc.)

Let me know what you think - happy to help with implementing this and/or updating the wiki