### PR TITLE
Format ESP.getChipId as an 8 character hex instead of 7 digit decimal

### DIFF
--- a/sonoff/xdrv_wemohue.ino
+++ b/sonoff/xdrv_wemohue.ino
@@ -53,14 +53,14 @@ const char WEMO_MSEARCH[] PROGMEM =
 
 String wemo_serial()
 {
-  char serial[15];
-  snprintf_P(serial, sizeof(serial), PSTR("201612K%07d"), ESP.getChipId());
+  char serial[16];
+  snprintf_P(serial, sizeof(serial), PSTR("201612K%08X"), ESP.getChipId());
   return String(serial);
 }
 
 String wemo_UUID()
 {
-  char uuid[26];
+  char uuid[27];
   snprintf_P(uuid, sizeof(uuid), PSTR("Socket-1_0-%s"), wemo_serial().c_str());
   return String(uuid);
 }


### PR DESCRIPTION
I have two sonoff duals with chip id's of 15163478 and 15165864. Adding an eighth would work for now, but 10 should be required. Although unlikely, it's possible for UUID collisions. I have two, but as some people have greater numbers of devices, and likely purchased in batches, it's plausible the issue will come up.