### PR TITLE
Add FORCE_DEFAULT_CFG to force reset of configuration.

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2739,8 +2739,12 @@ void setup()
 #ifdef USE_SPIFFS
   initSpiffs();
 #endif
+#ifdef FORCE_DEFAULT_CFG
+  CFG_Default();
+#else
   CFG_Load();
   CFG_Delta();
+#endif
 
   if (!sysCfg.model) {
     sysCfg.model = SONOFF;

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -22,6 +22,7 @@
 #define CFG_HOLDER             0x20161209   // [Reset 1] Change this value to load following default configuration parameters
 #define SAVE_DATA              1            // [SaveData] Save changed parameters to Flash (0 = disable, 1 - 3600 seconds)
 #define SAVE_STATE             1            // [SaveState] Save changed power state to Flash (0 = disable, 1 = enable)
+//#define FORCE_DEFAULT_CFG                 // [ForceDefaultCfg] Ignore previous configuration and initialize to defaults
 
 // -- Wifi -----------------------------------
 #define STA_SSID1              "indebuurt1"      // [Ssid1] Wifi SSID


### PR DESCRIPTION
I believe I had to erase_flash after jumping from my https://github.com/don-willingham/Sonoff-MQTT-OTA-Arduino/commits/dual-wemo back to https://github.com/arendst/Sonoff-MQTT-OTA-Arduino, in part due to my friendlyname change was not consistent with the upstream deprecation to ex_friendly, and an array added later in the structure.  Since I've embedded my sonoff duals in ceiling fans, pulling them down for maintenance would be very inconvenient.